### PR TITLE
chore: add infosec badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![scorecard-score](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/go-dbutil/maturity_score.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/go-dbutil)
+[![scorecard-status](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/go-dbutil/scorecard_status.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/go-dbutil)
 # go-dbutil
 Golang utilities for interacting with databases
 


### PR DESCRIPTION
update from `legion` on behalf of @dmaljovec

# What?
 - Ensure Octoguard badges exist on the Github repository
# Why?
 - This should give owners more visibiilty into this project's security posture